### PR TITLE
Fix pytubefix EOFError in GitHub Actions

### DIFF
--- a/main.py
+++ b/main.py
@@ -102,7 +102,7 @@ def video_downloader(url: str, max_retries: int = 3) -> Tuple[str, str]| None:
     for attempt in range(max_retries):
         try:
             logger.info(f"Download attempt {attempt + 1}/{max_retries}...")
-            yt = YouTube(url, use_po_token=True)
+            yt = YouTube(url, client='WEB')
             title = yt.title
             logger.info(f"Video Title: {title}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "psycopg2-binary>=2.9.11",
     "python-dotenv==1.1.1",
     "pytube==15.0.0",
-    "pytubefix==9.4.1",
+    "pytubefix>=10.3.6",
     "requests==2.32.5",
     "schedule==1.2.2",
     "sqlalchemy>=2.0.46",

--- a/uv.lock
+++ b/uv.lock
@@ -812,7 +812,7 @@ requires-dist = [
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "python-dotenv", specifier = "==1.1.1" },
     { name = "pytube", specifier = "==15.0.0" },
-    { name = "pytubefix", specifier = "==9.4.1" },
+    { name = "pytubefix", specifier = ">=10.3.6" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "schedule", specifier = "==1.2.2" },
     { name = "sqlalchemy", specifier = ">=2.0.46" },
@@ -916,6 +916,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/0a/2436550b1520091af0600dff547913cb2d66fbac27a8c33bc1b1bccd8d98/multidict-6.6.4-cp313-cp313t-win_amd64.whl", hash = "sha256:6d46a180acdf6e87cc41dc15d8f5c2986e1e8739dc25dbb7dac826731ef381a4", size = 53100, upload-time = "2025-08-11T12:08:13.823Z" },
     { url = "https://files.pythonhosted.org/packages/97/ea/43ac51faff934086db9c072a94d327d71b7d8b40cd5dcb47311330929ef0/multidict-6.6.4-cp313-cp313t-win_arm64.whl", hash = "sha256:756989334015e3335d087a27331659820d53ba432befdef6a718398b0a8493ad", size = 45501, upload-time = "2025-08-11T12:08:15.173Z" },
     { url = "https://files.pythonhosted.org/packages/fd/69/b547032297c7e63ba2af494edba695d781af8a0c6e89e4d06cf848b21d80/multidict-6.6.4-py3-none-any.whl", hash = "sha256:27d8f8e125c07cb954e54d75d04905a9bba8a439c1d84aca94949d4d03d8601c", size = 12313, upload-time = "2025-08-11T12:08:46.891Z" },
+]
+
+[[package]]
+name = "nodejs-wheel-binaries"
+version = "24.13.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/d0/81d98b8fddc45332f79d6ad5749b1c7409fb18723545eae75d9b7e0048fb/nodejs_wheel_binaries-24.13.1.tar.gz", hash = "sha256:512659a67449a038231e2e972d49e77049d2cf789ae27db39eff4ab1ca52ac57", size = 8056, upload-time = "2026-02-12T17:31:04.368Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/04/1ffe1838306654fcb50bcf46172567d50c8e27a76f4b9e55a1971fab5c4f/nodejs_wheel_binaries-24.13.1-py2.py3-none-macosx_13_0_arm64.whl", hash = "sha256:360ac9382c651de294c23c4933a02358c4e11331294983f3cf50ca1ac32666b1", size = 54757440, upload-time = "2026-02-12T17:30:35.748Z" },
+    { url = "https://files.pythonhosted.org/packages/66/f6/81ad81bc3bd919a20b110130c4fd318c7b6a5abb37eb53daa353ad908012/nodejs_wheel_binaries-24.13.1-py2.py3-none-macosx_13_0_x86_64.whl", hash = "sha256:035b718946793986762cdd50deee7f5f1a8f1b0bad0f0cfd57cad5492f5ea018", size = 54932957, upload-time = "2026-02-12T17:30:40.114Z" },
+    { url = "https://files.pythonhosted.org/packages/14/be/8e8a2bd50953c4c5b7e0fca07368d287917b84054dc3c93dd26a2940f0f9/nodejs_wheel_binaries-24.13.1-py2.py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:f795e9238438c4225f76fbd01e2b8e1a322116bbd0dc15a7dbd585a3ad97961e", size = 59287257, upload-time = "2026-02-12T17:30:43.781Z" },
+    { url = "https://files.pythonhosted.org/packages/58/57/92f6dfa40647702a9fa6d32393ce4595d0fc03c1daa9b245df66cc60e959/nodejs_wheel_binaries-24.13.1-py2.py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:978328e3ad522571eb163b042dfbd7518187a13968fe372738f90fdfe8a46afc", size = 59781783, upload-time = "2026-02-12T17:30:47.387Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a5/457b984cf675cf86ace7903204b9c36edf7a2d1b4325ddf71eaf8d1027c7/nodejs_wheel_binaries-24.13.1-py2.py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e1dc893df85299420cd2a5feea0c3f8482a719b5f7f82d5977d58718b8b78b5f", size = 61287166, upload-time = "2026-02-12T17:30:50.646Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/99/da515f7bc3bce35cfa6005f0e0c4e3c4042a466782b143112eb393b663be/nodejs_wheel_binaries-24.13.1-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:0e581ae219a39073dcadd398a2eb648f0707b0f5d68c565586139f919c91cbe9", size = 61870142, upload-time = "2026-02-12T17:30:54.563Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/c0/22001d2c96d8200834af7d1de5e72daa3266c7270330275104c3d9ddd143/nodejs_wheel_binaries-24.13.1-py2.py3-none-win_amd64.whl", hash = "sha256:d4c969ea0bcb8c8b20bc6a7b4ad2796146d820278f17d4dc20229b088c833e22", size = 41185473, upload-time = "2026-02-12T17:30:57.524Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c4/7532325f968ecfc078e8a028e69a52e4c3f95fb800906bf6931ac1e89e2b/nodejs_wheel_binaries-24.13.1-py2.py3-none-win_arm64.whl", hash = "sha256:caec398cb9e94c560bacdcba56b3828df22a355749eb291f47431af88cbf26dc", size = 38881194, upload-time = "2026-02-12T17:31:00.214Z" },
 ]
 
 [[package]]
@@ -1256,14 +1272,15 @@ wheels = [
 
 [[package]]
 name = "pytubefix"
-version = "9.4.1"
+version = "10.3.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
+    { name = "nodejs-wheel-binaries" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/9f/389cff9de23298bef0b12d922d8ae40cf7c35ab8ca5f1436a6b7d5f538d1/pytubefix-9.4.1.tar.gz", hash = "sha256:a3466cbbe2659f866c2dd91bf8ebdc8256e7494c9c3733292813b313daafcaad", size = 757979, upload-time = "2025-07-23T01:44:47.613Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/39/a45505a2becfcca6a797bd22ebacb56f205c65cc4940cea8e835e9d52e3c/pytubefix-10.3.6.tar.gz", hash = "sha256:06370bd53ae033a0a0d54b753836ed18f3ad16d93028ec8c42407bbf0f48272b", size = 1505679, upload-time = "2025-12-07T10:55:15.948Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/39/00a23743e47e62ac254f29ec30c8f6d340847c3b69e5f22f8f28493ecf37/pytubefix-9.4.1-py3-none-any.whl", hash = "sha256:e8625c1f1041b1cf91578843b32a3575b81e3eb49a0ad757b3fc7b9772d85680", size = 768648, upload-time = "2025-07-23T01:44:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/d1/006341b929ba9a7ec2660fae1b63c8ac7deb257abf412e41fe5f6bddff63/pytubefix-10.3.6-py3-none-any.whl", hash = "sha256:5475577e632d3bc6a70e5fb336f0c629dc6bbdb2a7bf5cecac0bf7a3fd01f6a1", size = 1516541, upload-time = "2025-12-07T10:55:13.735Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The issue was caused by `pytubefix` attempting to prompt the user for a `po_token` and `visitorData` via `input()` when `use_po_token=True` was set in a non-interactive environment (GitHub Actions).

To fix this:
1.  **Updated `pytubefix`** to version `10.3.6` or later. This version supports automated `po_token` generation using NodeJS.
2.  **Modified `main.py`** to use `client='WEB'` and removed `use_po_token=True`. In current `pytubefix` versions, the `WEB` client combined with the new internal logic handles tokens automatically without requiring user input.
3.  **Updated `uv.lock`** to include `nodejs-wheel-binaries`, which `pytubefix` uses for the automated token generation.

These changes ensure the script can run successfully in GitHub Actions without crashing due to an `EOFError`.

---
*PR created automatically by Jules for task [16096679400522157328](https://jules.google.com/task/16096679400522157328) started by @Jemo69*